### PR TITLE
[92] mongoose 미들웨어 이용,  리뷰 수에 따른 유저 level 변환기능 구현

### DIFF
--- a/model/User.js
+++ b/model/User.js
@@ -31,37 +31,24 @@ const userSchema = new mongoose.Schema({
   },
 });
 
-userSchema.pre("findOneAndUpdate", async function (next) {
-  const { reviewList } = await this.model.findById(this._conditions._id);
-
-  if (this._update.hasOwnProperty("$push")) {
-    if (reviewList.length < 4) {
-      this._update.$set = { level: "BRONZE" };
-      next();
-      return;
-    }
-    if (reviewList.length < 9) {
-      this._update.$set = { level: "SILVER" };
-      next();
-      return;
-    }
-    this._update.$set = { level: "GOLD" };
+userSchema.post("findOneAndUpdate", async function (doc, next) {
+  if (doc.reviewList.length < 5) {
+    doc.level = "BRONZE";
+    await doc.save();
     next();
     return;
   }
 
-  if (this._update.hasOwnProperty("$pull")) {
-    if (reviewList.length <= 5) {
-      this._update.$set = { level: "BRONZE" };
-      next();
-      return;
-    }
-    if (reviewList.length <= 10) {
-      this._update.$set = { level: "SILVER" };
-      next();
-      return;
-    }
-    this._update.$set = { level: "GOLD" };
+  if (doc.reviewList.length < 10) {
+    doc.level = "SILVER";
+    await doc.save();
+    next();
+    return;
+  }
+
+  if (doc.reviewList.length >= 10) {
+    doc.level = "GOLD";
+    await doc.save();
     next();
     return;
   }

--- a/model/User.js
+++ b/model/User.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-prototype-builtins */
 const mongoose = require("mongoose");
 
+const { USER_LEVEL, SOCIAL_SERVICE } = require("../utils/constants");
+
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
@@ -8,8 +10,8 @@ const userSchema = new mongoose.Schema({
   },
   level: {
     type: String,
-    enum: ["GOLD", "SILVER", "BRONZE"],
-    default: "BRONZE",
+    enum: [USER_LEVEL.GOLD, USER_LEVEL.SILVER, USER_LEVEL.BRONZE],
+    default: USER_LEVEL.BRONZE,
     required: true,
   },
   email: {
@@ -18,7 +20,7 @@ const userSchema = new mongoose.Schema({
   },
   socialService: {
     type: String,
-    enum: ["KAKAO", "NAVER"],
+    enum: [SOCIAL_SERVICE.KAKAO, SOCIAL_SERVICE.NAVER],
     required: true,
   },
   reviewList: {
@@ -33,21 +35,21 @@ const userSchema = new mongoose.Schema({
 
 userSchema.post("findOneAndUpdate", async function (doc, next) {
   if (doc.reviewList.length < 5) {
-    doc.level = "BRONZE";
+    doc.level = USER_LEVEL.BRONZE;
     await doc.save();
     next();
     return;
   }
 
   if (doc.reviewList.length < 10) {
-    doc.level = "SILVER";
+    doc.level = USER_LEVEL.SILVER;
     await doc.save();
     next();
     return;
   }
 
   if (doc.reviewList.length >= 10) {
-    doc.level = "GOLD";
+    doc.level = USER_LEVEL.GOLD;
     await doc.save();
     next();
     return;

--- a/service/user.js
+++ b/service/user.js
@@ -14,13 +14,16 @@ exports.getUserById = async function (id) {
 
 exports.addReviewToUser = async function (userId, reviewId) {
   return await User.findByIdAndUpdate(
-    { _id: userId },
-    { $push: { reviewList: reviewId } }
+    userId,
+    { $push: { reviewList: reviewId } },
+    { new: true }
   );
 };
 
 exports.deleteReviewByUserId = async function (userId, reviewId) {
-  return await User.findByIdAndUpdate(userId, {
-    $pull: { reviewList: reviewId },
-  });
+  return await User.findByIdAndUpdate(
+    userId,
+    { $pull: { reviewList: reviewId } },
+    { new: true }
+  );
 };

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -38,6 +38,12 @@ exports.SOCIAL_SERVICE = {
   NAVER: "NAVER",
 };
 
+exports.USER_LEVEL = {
+  GOLD: "GOLD",
+  SILVER: "SILVER",
+  BRONZE: "BRONZE",
+};
+
 exports.MINUTE_TO_MILLISECONDS = {
   THIRTY_MINUTES: 1800000,
 };


### PR DESCRIPTION
## Description

- 노션 칸반 카드 링크: [[92] 리뷰수에 따른 유저 LEVEL 자동 변환](https://www.notion.so/vanillacoding/LEVEL-e64acf1200564c478c65c8120326f698)

- mongoose middleware를 사용하였습니다.
```
// .../service/user.js
exports.addReviewToUser = async function (userId, reviewId) {
  return await User.findByIdAndUpdate(
    userId,
    { $push: { reviewList: reviewId } },
    { new: true }
  );
};

exports.deleteReviewByUserId = async function (userId, reviewId) {
  return await User.findByIdAndUpdate(
    userId,
    { $pull: { reviewList: reviewId } },
    { new: true }
  );
};

// .../model/User.js
userSchema.post("findOneAndUpdate", async function (doc, next) {
  if (doc.reviewList.length < 5) {
    doc.level = "BRONZE";
    await doc.save();
    next();
    return;
  }

  if (doc.reviewList.length < 10) {
    doc.level = "SILVER";
    await doc.save();
    next();
    return;
  }

  if (doc.reviewList.length >= 10) {
    doc.level = "GOLD";
    await doc.save();
    next();
    return;
  }
});
```
- `{ new: true }` 옵션을 사용해야  파라미터 doc에 `findOneAndUpdate` 결과가 반환됩니다.

## Checklist

- [x] 리뷰수 0 -> 10 까지, 10 -> 0까지 test 완료.